### PR TITLE
Lock simple-git version to allow this library to be used with node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lcov-parse": "0.0.10",
     "node-gitlab": "^1.6.0",
     "request": "^2.74.0",
-    "simple-git": "^1.48.0",
+    "simple-git": "~1.96.0",
     "shelljs": "0.7.8",
     "sloc": "^0.1.10",
     "xml2js": "^0.4.17",


### PR DESCRIPTION
simple-git above version 1.96.0 has a change in the dependency on the debug package -- from ^3.1.0 to ^4.0.1. attempting to use that package throws errors in node version 6, and we don't gain anything by upgrading, so this locks that version to 1.96.0.